### PR TITLE
feat: add STUDY_SCENE4_tilt_the_black_book_against_the_shelf task & add UpRight45 predicates

### DIFF
--- a/libero/libero/envs/predicates/__init__.py
+++ b/libero/libero/envs/predicates/__init__.py
@@ -5,7 +5,7 @@ VALIDATE_PREDICATE_FN_DICT = {
     "true": TruePredicateFn(),
     "false": FalsePredicateFn(),
     "in": In(),
-    # "incontact": InContactPredicateFn(),
+    "incontact": InContactPredicateFn(),
     "on": On(),
     "up": Up(),
     # "stack":     Stack(),
@@ -15,6 +15,7 @@ VALIDATE_PREDICATE_FN_DICT = {
     "close": Close(),
     "turnon": TurnOn(),
     "turnoff": TurnOff(),
+    "upright45": UpRight45(),
 }
 
 

--- a/libero/libero/envs/predicates/base_predicates.py
+++ b/libero/libero/envs/predicates/base_predicates.py
@@ -1,4 +1,7 @@
 from typing import List
+import numpy as np
+import robosuite.utils.transform_utils as transform_utils
+
 
 
 class Expression:
@@ -116,3 +119,15 @@ class TurnOn(UnaryAtomic):
 class TurnOff(UnaryAtomic):
     def __call__(self, arg):
         return arg.turn_off()
+
+
+class UpRight45(UnaryAtomic):
+    """Check if the object is upright within 45 degrees"""
+    def __call__(self, arg):
+        geom = arg.get_geom_state()
+        w, x, y, z = geom["quat"]
+        quat_for_rs = np.array([x, y, z, w])
+
+        R = transform_utils.quat2mat(quat_for_rs)
+        z_axis = R[:, 2]
+        return z_axis[2] >= 0.7071

--- a/tasks/STUDY_SCENE4_tilt_the_black_book_against_the_shelf.py
+++ b/tasks/STUDY_SCENE4_tilt_the_black_book_against_the_shelf.py
@@ -1,0 +1,113 @@
+"""This is a standalone file for create a task in libero."""
+from libero.libero.utils.bddl_generation_utils import (
+    get_xy_region_kwargs_list_from_regions_info,
+)
+from libero.libero.utils.mu_utils import register_mu, InitialSceneTemplates
+from libero.libero.utils.task_generation_utils import (
+    register_task_info,
+    get_task_info,
+    generate_bddl_from_task_info,
+)
+
+
+@register_mu(scene_type="study")
+class StudyScene4(InitialSceneTemplates):
+    def __init__(self):
+        fixture_num_info = {
+            "study_table": 1,
+            "wooden_two_layer_shelf": 1,
+        }
+
+        object_num_info = {
+            "black_book": 1,
+            "yellow_book": 2,
+        }
+
+        super().__init__(
+            workspace_name="study_table",
+            fixture_num_info=fixture_num_info,
+            object_num_info=object_num_info,
+        )
+
+    def define_regions(self):
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[0.0, 0.0],
+                region_name="study_table_init_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[0.0, 0.0],
+                region_name="yellow_book_right_init_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[0.05, -0.15],
+                region_name="black_book_init_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[0.0, 0.0],
+                region_name="black_book_goal_region",
+                target_name=self.workspace_name,
+                region_half_len=100.0,  # Large region to ensure the book is in contact
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[0.0, 0.28],
+                region_name="wooden_two_layer_shelf_init_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+                yaw_rotation=(0, 0),
+            )
+        )
+        self.xy_region_kwargs_list = get_xy_region_kwargs_list_from_regions_info(
+            self.regions
+        )
+
+    @property
+    def init_states(self):
+        states = [
+            (
+                "On",
+                "wooden_two_layer_shelf_1",
+                "study_table_wooden_two_layer_shelf_init_region",
+            ),
+            ("On", "yellow_book_1", "study_table_yellow_book_right_init_region"),
+            ("On", "black_book_1", "study_table_black_book_init_region"),
+        ]
+        return states
+
+
+
+def main():
+    scene_name = "study_scene4"
+    language = "Tilt the black book against the shelf"
+    register_task_info(
+        language,
+        scene_name=scene_name,
+        objects_of_interest=["wooden_two_layer_shelf_1", "black_book_1"],
+        goal_states=[
+            ("incontact", "black_book_1", "wooden_two_layer_shelf_1"),
+            ("on", "black_book_1", "study_table_black_book_goal_region"),
+            ("upright45", "black_book_1"),
+        ],
+    )
+
+
+    bddl_file_names, failures = generate_bddl_from_task_info()
+    print(bddl_file_names)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Predicate Updates:
* Re-enabled the `InContactPredicateFn` in `libero/libero/envs/predicates/__init__.py`, allowing it to be used in task definitions.
* Added the `UpRight45` predicate to check if an object is upright within 45 degrees, including its implementation in `libero/libero/envs/predicates/base_predicates.py`. [[1]](diffhunk://#diff-b3f1bb813fa96c3fd5a0db2991af407315f2b2059463113dadee03e5b7124053R18) [[2]](diffhunk://#diff-6e10f06dd912b23d71b497b593ae47041e06a727fc9e9d1404b3c42e340435f5R122-R133)

### Task Definition:
* Created a new standalone file `tasks/STUDY_SCENE4_tilt_the_black_book_against_the_shelf.py` to define the "Tilt the black book against the shelf" task. This includes scene setup, region definitions, initial states, and goal states utilizing the new predicates (`incontact`, `on`, and `upright45`).