### PR TITLE
New task: Hold the bowl in the air and its opening faces horizontally.

### DIFF
--- a/libero/libero/envs/predicates/base_predicates.py
+++ b/libero/libero/envs/predicates/base_predicates.py
@@ -267,11 +267,11 @@ class AxisAlignedWithin(UnaryAtomic):
         object_axis_world = R[:, axis_index]
         cos_angle = object_axis_world[2]
         
-        # # this is used to print the current angle of the axis with respect to Z+ for debugging
-        # # calculate current angle in degrees
-        # angle_rad = np.arccos(cos_angle)
-        # angle_deg = np.degrees(angle_rad)
-        # print(f"Current angle of {axis} axis with Z+ is {angle_deg:.2f} degrees")
+        # this is used to print the current angle of the axis with respect to Z+ for debugging
+        # calculate current angle in degrees
+        angle_rad = np.arccos(cos_angle)
+        angle_deg = np.degrees(angle_rad)
+        print(f"Current angle of {axis} axis with Z+ is {angle_deg:.2f} degrees")
 
         return cos_max <= cos_angle <= cos_min
 

--- a/libero/libero/envs/predicates/base_predicates.py
+++ b/libero/libero/envs/predicates/base_predicates.py
@@ -267,11 +267,11 @@ class AxisAlignedWithin(UnaryAtomic):
         object_axis_world = R[:, axis_index]
         cos_angle = object_axis_world[2]
         
-        # this is used to print the current angle of the axis with respect to Z+ for debugging
-        # calculate current angle in degrees
-        angle_rad = np.arccos(cos_angle)
-        angle_deg = np.degrees(angle_rad)
-        print(f"Current angle of {axis} axis with Z+ is {angle_deg:.2f} degrees")
+        # # this is used to print the current angle of the axis with respect to Z+ for debugging
+        # # calculate current angle in degrees
+        # angle_rad = np.arccos(cos_angle)
+        # angle_deg = np.degrees(angle_rad)
+        # print(f"Current angle of {axis} axis with Z+ is {angle_deg:.2f} degrees")
 
         return cos_max <= cos_angle <= cos_min
 

--- a/tasks/KITCHEN_SCENE1_hold_bowl_horizontally_in_the_air.py
+++ b/tasks/KITCHEN_SCENE1_hold_bowl_horizontally_in_the_air.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from libero.libero.utils.bddl_generation_utils import (
+    get_xy_region_kwargs_list_from_regions_info,
+)
+from libero.libero.utils.mu_utils import register_mu, InitialSceneTemplates
+from libero.libero.utils.task_generation_utils import (
+    register_task_info,
+    get_task_info,
+    generate_bddl_from_task_info,
+)
+
+from libero.libero.benchmark.mu_creation import *
+
+def main():
+
+    scene_name = "kitchen_scene1"
+    language = "Hold the bowl upright in the air and its opening faces horizontally."
+    register_task_info(
+        language,
+        scene_name=scene_name,
+        objects_of_interest=["plate_1", "akita_black_bowl_1", "wooden_cabinet_1"],
+        goal_states=[
+            ("InAir", "akita_black_bowl_1", 0.2),
+            ("Not", (
+                "InContact", "akita_black_bowl_1", "plate_1"
+            )),
+            ("Not", (
+                "InContact", "akita_black_bowl_1", "wooden_cabinet_1"
+            )),
+            ("AxisAlignedWithin", "akita_black_bowl_1", "z", 85, 95), # in degree
+        ]
+    )
+
+    bddl_file_names, failures = generate_bddl_from_task_info()
+    print(bddl_file_names)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new task script for generating a specific scene setup in the `libero` framework. The script defines a task where a bowl must be held upright in the air with its opening facing horizontally, and includes the necessary utilities and logic to register and generate the task.

### New Task Script Addition:

* [`tasks/KITCHEN_SCENE1_hold_bowl_horizontally_in_the_air.py`](diffhunk://#diff-c9c7d299207db47552587132ddc55cab72f97848d896c93b25ce24de4cf02ed8R1-R39): Added a new script to define and generate a task where a bowl (`akita_black_bowl_1`) is held upright in the air, ensuring it is not in contact with specified objects (`plate_1`, `wooden_cabinet_1`) and is aligned within a specific angular range along the z-axis. The script uses utilities from `libero` for task registration and BDDL file generation.