### PR TITLE
New task: Place the black book vertically between the two yellow books on top of the shelf

### DIFF
--- a/libero/libero/envs/predicates/__init__.py
+++ b/libero/libero/envs/predicates/__init__.py
@@ -33,6 +33,7 @@ VALIDATE_PREDICATE_FN_DICT = {
     "positionwithin": PositionWithin(),
     "above": Above(),
     "between": MidBetween(),
+    "relaxedbetween": RelaxedMidBetween(),
 }
 
 

--- a/libero/libero/envs/predicates/base_predicates.py
+++ b/libero/libero/envs/predicates/base_predicates.py
@@ -472,7 +472,7 @@ class Above(BinaryAtomic):
         return [BaseObjectState, BaseObjectState]
 
 class MidBetween(MultiarayAtomic):
-    """Check if M is between L and R along axis A."""
+    """Check if M is between L and R along axis A and in contact with both."""
 
     def __call__(self, L, M, R, A):
         assert A in {"x", "y", "z"}, "Axis must be one of 'x', 'y', or 'z'"
@@ -488,6 +488,27 @@ class MidBetween(MultiarayAtomic):
             )
             and L.check_contact(M)
             and M.check_contact(R)
+        )
+
+    def expected_arg_types(self):
+        return [BaseObjectState, BaseObjectState, BaseObjectState, str]
+    
+class RelaxedMidBetween(MultiarayAtomic):
+    """Check if M is between L and R along axis A without contact requirement."""
+
+    def __call__(self, L, M, R, A):
+        assert A in {"x", "y", "z"}, "Axis must be one of 'x', 'y', or 'z'"
+        pos_L = L.get_geom_state()["pos"]
+        pos_M = M.get_geom_state()["pos"]
+        pos_R = R.get_geom_state()["pos"]
+        axis_index = {"x": 0, "y": 1, "z": 2}[A]
+        
+        # print current positions for debugging
+        # print(f"Position L: {pos_L}, Position M: {pos_M}, Position R: {pos_R}")
+        
+        return (
+            (pos_L[axis_index] < pos_M[axis_index] < pos_R[axis_index])
+            or (pos_R[axis_index] < pos_M[axis_index] < pos_L[axis_index])
         )
 
     def expected_arg_types(self):

--- a/tasks/STUDY_SCENE4_black_book_between_two_yellow_books.py
+++ b/tasks/STUDY_SCENE4_black_book_between_two_yellow_books.py
@@ -1,0 +1,37 @@
+from libero.libero.utils.bddl_generation_utils import (
+    get_xy_region_kwargs_list_from_regions_info,
+)
+from libero.libero.utils.mu_utils import register_mu, InitialSceneTemplates
+from libero.libero.utils.task_generation_utils import (
+    generate_bddl_from_task_info,
+    register_task_info,
+)
+
+from libero.libero.benchmark.mu_creation import StudyScene4
+
+def main():
+    scene_name = "study_scene4"
+    language = "Place the black book vertically between the two yellow books on top of the shelf"
+    register_task_info(
+        language,
+        scene_name=scene_name,
+        objects_of_interest=["wooden_two_layer_shelf_1", "black_book_1"],
+        goal_states=[
+            # ("InContact", "black_book_1", "wooden_two_layer_shelf_1"),
+            ("On", "black_book_1", "wooden_two_layer_shelf_1_top_side"),
+            ("On", "yellow_book_1", "wooden_two_layer_shelf_1_top_side"),
+            ("On", "yellow_book_2", "wooden_two_layer_shelf_1_top_side"),
+            ("AxisAlignedWithin", "black_book_1", "z", 0, 5),
+            ("AxisAlignedWithin", "yellow_book_1", "z", 0, 5),
+            ("AxisAlignedWithin", "yellow_book_2", "z", 0, 5),
+            ("RelaxedBetween", "yellow_book_1", "black_book_1", "yellow_book_2", "x"),
+        ],
+    )
+
+
+    bddl_file_names, failures = generate_bddl_from_task_info()
+    print(bddl_file_names)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces a new predicate, `RelaxedMidBetween`, to the `libero` environment, updates the existing `MidBetween` predicate, and adds a new task script that utilizes the new predicate. The changes enhance the flexibility of spatial relationship checks and expand the task generation capabilities.

### Predicate Enhancements:

* **Added `RelaxedMidBetween` predicate**: A new predicate was introduced to check if an object is between two others along a specified axis without requiring contact. This includes its implementation in `libero/libero/envs/predicates/base_predicates.py` and its registration in `libero/libero/envs/predicates/__init__.py`. [[1]](diffhunk://#diff-b3f1bb813fa96c3fd5a0db2991af407315f2b2059463113dadee03e5b7124053R36) [[2]](diffhunk://#diff-6e10f06dd912b23d71b497b593ae47041e06a727fc9e9d1404b3c42e340435f5R495-R515)
* **Updated `MidBetween` predicate**: The documentation for the `MidBetween` predicate was updated to clarify that it checks for contact between the middle object and the two others.

### Task Generation:

* **New task script**: A new task script, `tasks/STUDY_SCENE4_black_book_between_two_yellow_books.py`, was added. It defines a task requiring a black book to be placed between two yellow books on a shelf using the `RelaxedBetween` predicate. The script includes task registration and BDDL generation logic.