### PR TITLE
Reproduce tabletop scene

### DIFF
--- a/libero/libero/benchmark/mu_creation.py
+++ b/libero/libero/benchmark/mu_creation.py
@@ -1573,3 +1573,111 @@ class StudyScene4(InitialSceneTemplates):
             ("On", "black_book_1", "study_table_black_book_init_region"),
         ]
         return states
+
+@register_mu(scene_type="tabletop_manipulation")
+class TabletopScene1(InitialSceneTemplates):
+    def __init__(self):
+
+        fixture_num_info = {
+            "table": 1,
+            "wooden_cabinet": 1,
+            "flat_stove": 1,
+            "wine_rack": 1,
+        }
+
+        object_num_info = {
+            "akita_black_bowl": 1,
+            "cream_cheese": 1,
+            "wine_bottle": 1,
+            "plate": 1,
+        }
+
+        super().__init__(
+            workspace_name="main_table",
+            fixture_num_info=fixture_num_info,
+            object_num_info=object_num_info,
+        )
+
+    def define_regions(self):
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[0.05, -0.02],
+                region_name="plate_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[-0.09, 0],
+                region_name="akita_black_bowl_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[-0.2, -0.05],
+                region_name="wine_bottle_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[-0.05, 0.13],
+                region_name="cream_cheese_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[-0.05, 0.21],
+                region_name="stove_front_region",
+                target_name=self.workspace_name,
+                region_half_len=0.04,
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[0.03, -0.24],
+                region_name="cabinet_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+                yaw_rotation=(np.pi, np.pi)
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[-0.41, 0.21],
+                region_name="stove_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+            )
+        )
+        self.regions.update(
+            self.get_region_dict(
+                region_centroid_xy=[-0.26, -0.26],
+                region_name="wine_rack_region",
+                target_name=self.workspace_name,
+                region_half_len=0.01,
+                yaw_rotation=(np.pi, np.pi)
+            )
+        )
+        self.xy_region_kwargs_list = get_xy_region_kwargs_list_from_regions_info(
+            self.regions
+        )
+
+    @property
+    def init_states(self):
+        states = [
+            ("On", "wine_bottle_1", "main_table_wine_bottle_region"),
+            ("On", "akita_black_bowl_1", "main_table_akita_black_bowl_region"),
+            ("On", "plate_1", "main_table_plate_region"),
+            ("On", "cream_cheese_1", "main_table_cream_cheese_region"),
+            ("On", "wooden_cabinet_1", "main_table_cabinet_region"),
+            ("On", "flat_stove_1", "main_table_stove_region"),
+            ("On", "wine_rack_1", "main_table_wine_rack_region"),
+        ]
+        return states


### PR DESCRIPTION
This pull request introduces a new scene class, `TabletopScene1`, to the `libero/benchmark/mu_creation.py` file. The class defines a tabletop manipulation scene with specific fixtures, objects, regions, and initial states, enhancing the flexibility and functionality of the benchmark module.

### New Scene Class Addition:

* **`TabletopScene1` Class**: A new class for tabletop manipulation scenes was added. It defines:
  - **Fixtures and Objects**: Includes predefined numbers of items like tables, cabinets, and wine bottles. (`[libero/libero/benchmark/mu_creation.pyR1576-R1683](diffhunk://#diff-7bf96ce95171f3448bac731d2431f60723caca83d616fbabf50d80e3e3421e88R1576-R1683)`)
  - **Regions**: Specifies regions with attributes such as centroid coordinates, names, target workspace, and dimensions. Some regions include yaw rotation for orientation. (`[libero/libero/benchmark/mu_creation.pyR1576-R1683](diffhunk://#diff-7bf96ce95171f3448bac731d2431f60723caca83d616fbabf50d80e3e3421e88R1576-R1683)`)
  - **Initial States**: Establishes the starting positions of objects on the workspace, linking them to their respective regions. (`[libero/libero/benchmark/mu_creation.pyR1576-R1683](diffhunk://#diff-7bf96ce95171f3448bac731d2431f60723caca83d616fbabf50d80e3e3421e88R1576-R1683)`)
  
Reproduced scene:
<img width="642" alt="image" src="https://github.com/user-attachments/assets/1299244d-e3b2-4f53-9d48-06499fb5c57c" />
Original:
<img width="256" alt="image" src="https://github.com/user-attachments/assets/5ca329b7-3be5-4c37-92ae-4b95e6cc42c0" />