### PR TITLE
New tasks: lay book flat on top side of the shelf / on the top level

### DIFF
--- a/tasks/STUDY_SCENE4_place_book_top_cabinet_flat.py
+++ b/tasks/STUDY_SCENE4_place_book_top_cabinet_flat.py
@@ -1,0 +1,31 @@
+from libero.libero.utils.bddl_generation_utils import (
+    get_xy_region_kwargs_list_from_regions_info,
+)
+from libero.libero.utils.mu_utils import register_mu, InitialSceneTemplates
+from libero.libero.utils.task_generation_utils import (
+    generate_bddl_from_task_info,
+    register_task_info,
+)
+
+from libero.libero.benchmark.mu_creation import StudyScene4
+
+def main():
+    scene_name = "study_scene4"
+    language = "Place the black book on the top side of the bookshelf, laying it flat."
+    register_task_info(
+        language,
+        scene_name=scene_name,
+        objects_of_interest=["wooden_two_layer_shelf_1", "black_book_1"],
+        goal_states=[
+            ("On", "black_book_1", "wooden_two_layer_shelf_1_top_side"),
+            ("AxisAlignedWithin", "black_book_1", "z", 85, 95),
+        ],
+    )
+
+
+    bddl_file_names, failures = generate_bddl_from_task_info()
+    print(bddl_file_names)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks/STUDY_SCENE4_put_book_top_shelf_flat.py
+++ b/tasks/STUDY_SCENE4_put_book_top_shelf_flat.py
@@ -1,0 +1,32 @@
+from libero.libero.utils.bddl_generation_utils import (
+    get_xy_region_kwargs_list_from_regions_info,
+)
+from libero.libero.utils.mu_utils import register_mu, InitialSceneTemplates
+from libero.libero.utils.task_generation_utils import (
+    generate_bddl_from_task_info,
+    register_task_info,
+)
+
+from libero.libero.benchmark.mu_creation import StudyScene4
+
+def main():
+    scene_name = "study_scene4"
+    language = "Place the black book on a top shelf of the bookshelf, laying it flat."
+    register_task_info(
+        language,
+        scene_name=scene_name,
+        objects_of_interest=["wooden_two_layer_shelf_1", "black_book_1"],
+        goal_states=[
+            ("In", "black_book_1", "wooden_two_layer_shelf_1_top_region"),
+            ("PositionWithin", "black_book_1", 0, 0, 0.97, 1000, 1000, 0.01), # z value for flat book on the top shelf is about 0.97
+            ("AxisAlignedWithin", "black_book_1", "z", 85, 95)
+        ],
+    )
+
+
+    bddl_file_names, failures = generate_bddl_from_task_info()
+    print(bddl_file_names)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds a new task script for scene generation in the `tasks` directory. The script defines a task where a black book must be placed on the top side of a bookshelf in a specific orientation.

### New task script addition:

* [`tasks/STUDY_SCENE4_place_book_top_cabinet_flat.py`](diffhunk://#diff-0886ae7de894010ed454ce2ea85e5b309246edbfdbf59ae24bdf73f1b4535d95R1-R31): Introduced a new script for generating a scene (`study_scene4`) with a task where the black book is placed flat on the top side of a bookshelf. The script uses utility functions for task registration and BDDL generation, and specifies objects of interest and goal states.