### PR TITLE
Fix the push problem

### DIFF
--- a/tasks/LIVING_ROOM_SCENE2_move_the_milk_until_it_contacts_the_orange_juice_keep_all_objects_upright.py
+++ b/tasks/LIVING_ROOM_SCENE2_move_the_milk_until_it_contacts_the_orange_juice_keep_all_objects_upright.py
@@ -14,7 +14,7 @@ from libero.libero.benchmark.mu_creation import *
 
 def main():
     scene_name = "living_room_scene2"
-    language = "Push the milk until it contacts the orange juice"
+    language = "Move the milk until it contacts the orange juice. Keep all objects upright."
     register_task_info(
         language,
         scene_name=scene_name,
@@ -23,7 +23,7 @@ def main():
             ("InContact", "milk_1", "orange_juice_1"),
             ("AxisAlignedWithin", "milk_1", "y", 0, 15),
             ("AxisAlignedWithin", "orange_juice_1", "y", 0, 15),
-            ("PositionWithin", "orange_juice_1", 0, -0.25, 0.5, 0.1, 0.1, 0.1)
+            ("PositionWithin", "orange_juice_1", 0, -0.25, 0.5, 0.1, 0.1, 0.01)
         ],
     )
 


### PR DESCRIPTION
Change the instruction from "Push the milk until it contacts the orange juice." to "Move the milk until it contacts the orange juice. Keep all objects upright." since it's hard to check whether the robot pushed the objects in LIBERO.