### PR TITLE
feat: implement stateful predicates

### DIFF
--- a/libero/libero/envs/predicates/__init__.py
+++ b/libero/libero/envs/predicates/__init__.py
@@ -1,4 +1,5 @@
 from .base_predicates import *
+from .predicate_wrapper import *
 
 
 VALIDATE_PREDICATE_FN_DICT = {
@@ -61,8 +62,14 @@ VALIDATE_PREDICATE_FN_DICT = {
     "axisalignedwithinworldaxis": AxisAlignedWithinWorldAxis(),
     "istouchingsideaxis": IsTouchingSideAxis(),
     "neuraljudge": NeuralJudge(),
-
 }
+
+# wrapper predicates
+VALIDATE_PREDICATE_FN_DICT.update({
+    "constraintalways": ConstraintAlways(),
+    "constraintnever": ConstraintNever(),
+    "constraintonce": ConstraintOnce(),
+})
 
 
 def update_predicate_fn_dict(fn_key, fn_name):

--- a/libero/libero/envs/predicates/predicate_wrapper.py
+++ b/libero/libero/envs/predicates/predicate_wrapper.py
@@ -1,0 +1,64 @@
+from .base_predicates import Expression
+from typing import List
+
+class PredicateWrapper(Expression):
+    """
+    A wrapper for predicates that allows them to be used as expressions.
+    This class is used to wrap predicates so they can be used in the expression
+    system of the environment.
+    """
+
+    def __init__(self):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError("PredicateWrapper should not be called directly. Use a specific predicate class instead.")
+
+    def expected_arg_types(self) -> List[type]:
+        raise NotImplementedError
+    
+    def __str__(self):
+        return f"{self.__class__.__name__}()"
+    
+
+class Constraint(PredicateWrapper):
+    def __init__(self):
+        super().__init__()
+        if not hasattr(self, 'constraint_satisfied'):
+            raise NotImplementedError("Subclasses must define 'constraint_satisfied' attribute.")
+        
+    def __call__(self, arg):
+        raise NotImplementedError("Subclasses should implement this method.")
+    
+    def expected_arg_types(self):
+        return [bool]
+
+
+class ConstraintAlways(Constraint):
+    def __init__(self):
+        self.constraint_satisfied = True
+        super().__init__()
+    
+    def __call__(self, arg):
+        self.constraint_satisfied = arg and self.constraint_satisfied
+        return self.constraint_satisfied
+
+
+class ConstraintNever(Constraint):
+    def __init__(self):
+        self.constraint_satisfied = True
+        super().__init__()
+    
+    def __call__(self, arg):
+        self.constraint_satisfied = not arg and self.constraint_satisfied
+        return self.constraint_satisfied
+
+
+class ConstraintOnce(Constraint):
+    def __init__(self):
+        self.constraint_satisfied = False
+        super().__init__()
+    
+    def __call__(self, arg):
+        self.constraint_satisfied = arg or self.constraint_satisfied
+        return self.constraint_satisfied


### PR DESCRIPTION
This pull request refactors the handling of constraints in the `bddl_base_domain` environment by introducing a predicate wrapper system. The changes remove direct constraint handling from the environment and delegate it to specialized predicate classes, improving modularity and maintainability. Additionally, the predicate dictionary (`VALIDATE_PREDICATE_FN_DICT`) is deep-copied to ensure isolation between instances.

### Refactoring constraint handling:

* [`libero/libero/envs/bddl_base_domain.py`](diffhunk://#diff-d495b576f8682daf56e13b50c0653b8526714139e2474c4af1607611eefc04d8L860-L896): Removed the `_check_constraint` method and its associated logic for managing constraint satisfaction. Constraints are now handled through dedicated predicate classes.
* [`libero/libero/envs/predicates/__init__.py`](diffhunk://#diff-b3f1bb813fa96c3fd5a0db2991af407315f2b2059463113dadee03e5b7124053L64-R73): Added wrapper predicates (`ConstraintAlways`, `ConstraintNever`, and `ConstraintOnce`) to the `VALIDATE_PREDICATE_FN_DICT`. These classes encapsulate constraint logic.

### Predicate wrapper system:

* [`libero/libero/envs/predicates/predicate_wrapper.py`](diffhunk://#diff-c153723ca351447265ee14f9831e75f74ec5ab56f513736d05d57016cb021aa3R1-R64): Introduced a new `PredicateWrapper` base class and its subclasses (`ConstraintAlways`, `ConstraintNever`, `ConstraintOnce`) to manage constraint evaluation. These classes provide a modular approach to predicate logic.

### Code improvements:

* [`libero/libero/envs/bddl_base_domain.py`](diffhunk://#diff-d495b576f8682daf56e13b50c0653b8526714139e2474c4af1607611eefc04d8L139-R140): Updated references to `VALIDATE_PREDICATE_FN_DICT` to use a deep copy (`self.VALIDATE_PREDICATE_FN_DICT`) for instance-level isolation. [[1]](diffhunk://#diff-d495b576f8682daf56e13b50c0653b8526714139e2474c4af1607611eefc04d8L139-R140) [[2]](diffhunk://#diff-d495b576f8682daf56e13b50c0653b8526714139e2474c4af1607611eefc04d8L801-R799)
* [`libero/libero/envs/bddl_base_domain.py`](diffhunk://#diff-d495b576f8682daf56e13b50c0653b8526714139e2474c4af1607611eefc04d8L905-R870): Modified `_eval_predicate` to use the instance-level predicate dictionary (`self.VALIDATE_PREDICATE_FN_DICT`).