### PR TITLE
Feat/sequential predicate

### DIFF
--- a/docs/annotation_guideline.md
+++ b/docs/annotation_guideline.md
@@ -327,7 +327,7 @@ goal_states = [
 ]
 ```
 
-### Sequencial
+### Sequential
 You can define sequential tasks using the `Sequential` predicate. This allows you to specify a sequence of conditions that must be met in order, enabling more complex task structures.
 ```python
 ("Sequential", (

--- a/docs/annotation_guideline.md
+++ b/docs/annotation_guideline.md
@@ -326,3 +326,25 @@ goal_states = [
     ("ConstraintNever", ("InContact", "akita_black_bowl_1", "plate_1")),
 ]
 ```
+
+### Sequencial
+You can define sequential tasks using the `Sequential` predicate. This allows you to specify a sequence of conditions that must be met in order, enabling more complex task structures.
+```python
+("Sequential", (
+    ("All", (
+        ("Close", "wooden_cabinet_1_middle_region"),
+        ("Not", ("InContact", "akita_black_bowl_1", "plate_1")),
+    )),
+    ("All", (
+        ("InContact", "akita_black_bowl_1", "plate_1"),
+        ("ConstraintAlways", ("Upright", "akita_black_bowl_1")),
+    ))
+))
+```
+For this example, the first condition requires the cabinet to be closed and the bowl not to be in contact with the plate. Only after the first condition is satisfied, the second condition will be checked, which requires the bowl to be in contact with the plate and remain upright.
+
+### Watch
+The `Watch` predicate allows you to monitor a specific predicate condition throughout the task execution. It always returns `True` and is useful for tracking conditions without affecting task success.
+```python
+("Watch", ("InContact", "gripper0_finger1", "akita_black_bowl_1"))
+```

--- a/libero/libero/envs/bddl_base_domain.py
+++ b/libero/libero/envs/bddl_base_domain.py
@@ -13,7 +13,7 @@ import robosuite.macros as macros
 import mujoco
 
 import libero.libero.envs.bddl_utils as BDDLUtils
-from libero.libero.envs.predicates.predicate_wrapper import Constraint
+from libero.libero.envs.predicates.predicate_wrapper import Constraint, StatefulWrapper
 from libero.libero.envs.robots import *
 from libero.libero.envs.utils import *
 from libero.libero.envs.object_states import *
@@ -901,7 +901,7 @@ class BDDLBaseDomain(SingleArmEnv):
         if variable_len_predicate:
             evaluated_args = (tuple(evaluated_args),)
 
-        if isinstance(predicate_fn, Constraint):
+        if isinstance(predicate_fn, StatefulWrapper):
             predicate_str = f"{str(state)}"
             return predicate_fn(predicate_str, *evaluated_args)
         

--- a/libero/libero/envs/bddl_base_domain.py
+++ b/libero/libero/envs/bddl_base_domain.py
@@ -13,7 +13,7 @@ import robosuite.macros as macros
 import mujoco
 
 import libero.libero.envs.bddl_utils as BDDLUtils
-from libero.libero.envs.predicates.predicate_wrapper import Constraint, StatefulWrapper
+from libero.libero.envs.predicates.predicate_wrapper import Constraint, Sequential, StatefulWrapper
 from libero.libero.envs.robots import *
 from libero.libero.envs.utils import *
 from libero.libero.envs.object_states import *
@@ -879,6 +879,16 @@ class BDDLBaseDomain(SingleArmEnv):
             )
 
         evaluated_args = []
+
+        if isinstance(predicate_fn, Sequential):
+            predicate_str = f"{str(state)}"
+            predicate_fn.init_by_name(predicate_str)
+            expected_index = predicate_fn.state[predicate_str]["NextExpectedIndex"]
+            val = self._eval_predicate(arg_exprs[0][expected_index])
+            evaluated_args = [False] * len(arg_exprs[0])
+            evaluated_args[expected_index] = val
+            return predicate_fn(predicate_str, evaluated_args)
+
 
         # unwrap arguments for variable-length truth predicates, e.g., Any, All, ...
         variable_len_predicate = False

--- a/libero/libero/envs/debug.py
+++ b/libero/libero/envs/debug.py
@@ -22,18 +22,18 @@ def print_states(goal_state, results, object_states_dict, debug_time):
     
     print("Detect time:", debug_time)
     predicate_str_len = 60
-    print("┌" + "─" * predicate_str_len + "┬" + "─" * 10 + "┐")
-    print("│" + " predicate".ljust(predicate_str_len) + "│" + " result".ljust(10) + "│")
-    print("├" + "─" * predicate_str_len + "┼" + "─" * 10 + "┤")
+    print("┌" + "─" * predicate_str_len + "┬" + "─" * 50 + "┐")
+    print("│" + " predicate".ljust(predicate_str_len) + "│" + " result".ljust(50) + "│")
+    print("├" + "─" * predicate_str_len + "┼" + "─" * 50 + "┤")
     
     for i, (state, result) in enumerate(zip(goal_state, results)):
         state_str = str(state)
         if len(state_str) > predicate_str_len:
             state_str = state_str[:predicate_str_len-3] + "..."
         result_str = str(result)
-        print("│" + state_str.ljust(predicate_str_len) +"│ " + result_str.ljust(8) + " │")
+        print("│" + state_str.ljust(predicate_str_len) +"│" + result_str.ljust(50) + "│")
         
-    print("└" + "─" * predicate_str_len + "┴" + "─" * 10 + "┘")
+    print("└" + "─" * predicate_str_len + "┴" + "─" * 50 + "┘")
 
     # print the object states
     object_name_str_len = 30

--- a/libero/libero/envs/predicates/__init__.py
+++ b/libero/libero/envs/predicates/__init__.py
@@ -69,6 +69,10 @@ VALIDATE_PREDICATE_FN_DICT.update({
     "constraintalways": ConstraintAlways(),
     "constraintnever": ConstraintNever(),
     "constraintonce": ConstraintOnce(),
+
+    "sequential": Sequential(),
+    "relaxedsequential": RelaxedSequential(),
+    "watch": Watch(),
 })
 
 

--- a/libero/libero/envs/predicates/__init__.py
+++ b/libero/libero/envs/predicates/__init__.py
@@ -71,7 +71,6 @@ VALIDATE_PREDICATE_FN_DICT.update({
     "constraintonce": ConstraintOnce(),
 
     "sequential": Sequential(),
-    "relaxedsequential": RelaxedSequential(),
     "watch": Watch(),
 })
 

--- a/libero/libero/envs/predicates/predicate_wrapper.py
+++ b/libero/libero/envs/predicates/predicate_wrapper.py
@@ -19,39 +19,179 @@ class PredicateWrapper(Expression):
     
     def __str__(self):
         return f"{self.__class__.__name__}()"
+
+
+class BoolResultWrapper:
+    def __init__(self, result: bool, print_result):
+        self.result = result
+        self.print_result = print_result
+    
+    def __bool__(self):
+        return self.result
+
+    def __str__(self):
+        return f"{self.print_result}"
     
 
-class Constraint(PredicateWrapper):
+class Watch(PredicateWrapper):
+    def __call__(self, args):
+        return BoolResultWrapper(True, args)
+
+    def expected_arg_types(self) -> List[type]:
+        return [bool]
+
+
+class StatefulWrapper(PredicateWrapper):
     def __init__(self):
         super().__init__()
-        self.constraint_satisfied = {}
-        
-    def __call__(self, name, arg):
+        self.state = {}
+
+    def __call__(self, name, *arg):
         raise NotImplementedError("Subclasses should implement this method.")
     
+    def reset(self):
+        self.state.clear()
+    
+    def expected_arg_types(self):
+        raise NotImplementedError("Subclasses should implement this method.")
+    
+
+class Constraint(StatefulWrapper):
     def expected_arg_types(self):
         return [bool]
 
 
 class ConstraintAlways(Constraint):
-    def __call__(self, name, arg):
-        if name not in self.constraint_satisfied:
-            self.constraint_satisfied[name] = True
-        self.constraint_satisfied[name] = arg and self.constraint_satisfied[name]
-        return self.constraint_satisfied[name]
+    def __call__(self, name, *arg):
+        if len(arg) != 1:
+            raise ValueError("ConstraintAlways expects exactly one argument.")
+        if name not in self.state:
+            self.state[name] = True
+        self.state[name] = arg[0] and self.state[name]
+        return self.state[name]
 
 
 class ConstraintNever(Constraint):
-    def __call__(self, name, arg):
-        if name not in self.constraint_satisfied:
-            self.constraint_satisfied[name] = True
-        self.constraint_satisfied[name] = not arg and self.constraint_satisfied[name]
-        return self.constraint_satisfied[name]
+    def __call__(self, name, *arg):
+        if len(arg) != 1:
+            raise ValueError("ConstraintNever expects exactly one argument.")
+        if name not in self.state:
+            self.state[name] = True
+        self.state[name] = not arg[0] and self.state[name]
+        return self.state[name]
 
+
+class ConstraintAlwaysAfter(Constraint):
+    def __call__(self, name, *arg):
+        if len(arg) != 2:
+            raise ValueError("ConstraintAlwaysAfter expects exactly two arguments.")
+        if name not in self.state:
+            self.state[name] = (False, True)
+        if not self.state[name][0]:
+            self.state[name] = (arg[0], self.state[name][1])
+        else:
+            self.state[name] = (self.state[name][0], arg[1] and self.state[name][1])
+        return self.state[name][0] and self.state[name][1]
+    
+    def expected_arg_types(self):
+        return [bool, bool]  # Expecting a tuple of (name, arg)
 
 class ConstraintOnce(Constraint):
-    def __call__(self, name, arg):
-        if name not in self.constraint_satisfied:
-            self.constraint_satisfied[name] = False
-        self.constraint_satisfied[name] = arg or self.constraint_satisfied[name]
-        return self.constraint_satisfied[name]
+    def __call__(self, name, *arg):
+        if name not in self.state:
+            self.state[name] = False
+        self.state[name] = arg[0] or self.state[name]
+        return self.state[name]
+
+
+class Sequential(StatefulWrapper):
+    """
+    A wrapper for predicates that enforces a sequential order of execution.
+    This class is used to ensure that predicates are satisfied in a specific order.
+    """
+    def __call__(self, name, *arg):
+        """
+        Check if the current state is a continuation of the last state.
+
+        Args:
+            name (str): The name of the predicate.
+            arg (tuple): tuple of bool objects representing the current state.
+        """
+        arg = arg[0]
+
+        if name not in self.state:
+            self.state[name] = {
+                "Sequential": True,
+                "LastState": [False] * len(arg),
+                "NextExpectedIndex": 0
+                }
+
+        if not self.state[name]["Sequential"]:
+            return BoolResultWrapper(False, f"{arg} Failed")
+        
+        # Sequential means: once a position becomes True, it stays True
+        # and new True values can only appear at the next expected position
+        for i in range(len(arg)):
+            # If a previously True value becomes False, it's not sequential
+            if self.state[name]["LastState"][i] and not arg[i]:
+                self.state[name]["Sequential"] = False
+                return BoolResultWrapper(False, f"{arg} Failed")
+            
+            # If a new True appears, it must be at the next expected sequential position
+            if not self.state[name]["LastState"][i] and arg[i]:
+                if i != self.state[name]["NextExpectedIndex"]:
+                    self.state[name]["Sequential"] = False
+                    return BoolResultWrapper(False, f"{arg} Failed")
+                self.state[name]["NextExpectedIndex"] += 1
+        
+        # Update the last state
+        self.state[name]["LastState"] = list(arg)
+        return BoolResultWrapper(all(arg), f"{arg} Is Sequential")
+
+    def expected_arg_types(self):
+        return [tuple]
+
+
+class RelaxedSequential(StatefulWrapper):
+    """
+    A wrapper for predicates that enforces sequential progression without persistence.
+    Similar to Sequential, but allows previously achieved positions to become False again.
+    Only requires that new True values appear in sequential order (starting from arg[0]).
+    """
+    def __call__(self, name, *arg):
+        """
+        Check if new True values appear in sequential order.
+
+        Args:
+            name (str): The name of the predicate.
+            arg (tuple): tuple of bool objects representing the current state.
+        """
+        arg = arg[0]
+
+        if name not in self.state:
+            self.state[name] = {
+                "Sequential": True,
+                "LastState": list(arg),
+                "NextExpectedIndex": 0
+                }
+
+        if not self.state[name]["Sequential"]:
+            return BoolResultWrapper(False, f"{arg} Failed")
+        
+        # RelaxedSequential means: once a position becomes True, it can become False again,
+        # and new True values can only appear at the next expected position
+        for i in range(self.state[name]["NextExpectedIndex"], len(arg)):
+            # If a new True appears, it must be at the next expected sequential position
+            if not self.state[name]["LastState"][i] and arg[i]:
+                if i != self.state[name]["NextExpectedIndex"]:
+                    self.state[name]["Sequential"] = False
+                    return BoolResultWrapper(False, f"{arg} Failed")
+                self.state[name]["NextExpectedIndex"] += 1
+        
+        # Update the last state
+        self.state[name]["LastState"] = list(arg)
+
+        return BoolResultWrapper(arg[-1], f"{arg} Is Relaxed Sequential")
+
+    def expected_arg_types(self):
+        return [tuple]


### PR DESCRIPTION
This pull request introduces enhancements to predicate handling in the `libero` environment, focusing on adding new predicates (`Sequential` and `Watch`), improving stateful predicate wrappers, and refining debugging outputs. These changes aim to enable more complex task structures and improve monitoring and debugging capabilities.

### Predicate Enhancements:
* **Added `Sequential` Predicate**: Enables defining sequential tasks by specifying conditions that must be met in order, facilitating complex task structures. (`docs/annotation_guideline.md`, `libero/libero/envs/predicates/predicate_wrapper.py`, [[1]](diffhunk://#diff-94911f3abfb8daceb9ce3c8e1074c1c139f22784051724acf65e9715e0da2737R329-R350) [[2]](diffhunk://#diff-c153723ca351447265ee14f9831e75f74ec5ab56f513736d05d57016cb021aa3L24-R158)
* **Added `Watch` Predicate**: Allows monitoring specific conditions throughout task execution without affecting task success. (`docs/annotation_guideline.md`, `libero/libero/envs/predicates/predicate_wrapper.py`, [[1]](diffhunk://#diff-94911f3abfb8daceb9ce3c8e1074c1c139f22784051724acf65e9715e0da2737R329-R350) [[2]](diffhunk://#diff-c153723ca351447265ee14f9831e75f74ec5ab56f513736d05d57016cb021aa3L24-R158)

### Stateful Predicate Wrappers:
* **Introduced `StatefulWrapper`**: A base class for predicates requiring state management, replacing the `constraint_satisfied` dictionary with a unified `state` dictionary. (`libero/libero/envs/predicates/predicate_wrapper.py`, [libero/libero/envs/predicates/predicate_wrapper.pyL24-R158](diffhunk://#diff-c153723ca351447265ee14f9831e75f74ec5ab56f513736d05d57016cb021aa3L24-R158))
* **Refactored Existing Constraints**: Updated `ConstraintAlways`, `ConstraintNever`, and `ConstraintOnce` to use the new `StatefulWrapper` structure for better consistency and extensibility. (`libero/libero/envs/predicates/predicate_wrapper.py`, [libero/libero/envs/predicates/predicate_wrapper.pyL24-R158](diffhunk://#diff-c153723ca351447265ee14f9831e75f74ec5ab56f513736d05d57016cb021aa3L24-R158))

### Debugging Improvements:
* **Enhanced Debug Output Formatting**: Increased the width of the "result" column in debug output to improve readability when printing predicate states and results. (`libero/libero/envs/debug.py`, [libero/libero/envs/debug.pyL25-R36](diffhunk://#diff-d3ca8bbe3cce3452bc4c8b0b15f0a514408e544667a8fcfa03d00dbba87685b6L25-R36))

These changes collectively enhance the flexibility, maintainability, and usability of the predicate system in the `libero` environment.