### PR TITLE
New intial state open ratio

### DIFF
--- a/libero/libero/envs/bddl_base_domain.py
+++ b/libero/libero/envs/bddl_base_domain.py
@@ -740,6 +740,26 @@ class BDDLBaseDomain(SingleArmEnv):
                         joint_ranges=joint_ranges,
                     )
                     self.object_property_initializers.append(property_initializer)
+            elif state[0] == "openratio":
+                if state[1] in self.object_states_dict and hasattr(
+                    self.object_states_dict[state[1]], "set_joint"
+                ):
+                    obj = self.get_object(state[1])
+                    open_ranges = obj.object_properties["articulation"][
+                            "default_open_ranges"
+                        ]
+                    close_ranges = obj.object_properties["articulation"][
+                            "default_open_ranges"
+                        ]
+                    joint_ranges = [(open_ranges[0]+close_ranges[0])*float(state[2])/2, (open_ranges[1]+close_ranges[1])*float(state[2])/2]
+
+
+                    property_initializer = OpenCloseSampler(
+                        name=obj.name,
+                        state_type=state[0],
+                        joint_ranges=joint_ranges,
+                    )
+                    self.object_property_initializers.append(property_initializer)
 
         # Place objects that are on sites
         for state in conditioned_initial_place_state_on_sites:

--- a/libero/libero/envs/regions/object_property_sampler.py
+++ b/libero/libero/envs/regions/object_property_sampler.py
@@ -89,7 +89,7 @@ class OpenCloseSampler(ObjectPropertySampler):
         mujoco_objects=None,
         joint_ranges=(0.0, 0.0),
     ):
-        assert state_type in ["open", "close"]
+        assert state_type in ["open", "close", "openratio"]
         self.state_type = state_type
         self.joint_ranges = joint_ranges
         assert self.joint_ranges[0] <= self.joint_ranges[1]


### PR DESCRIPTION
**OpenRatio**
- Allows the task annotator to set the openratio of an articulated object's region.
- Works similar to the OpenRatio predicate.
- Example use cases:
           1. ("OpenRatio", "wooden_cabinet_1_top_region", 0.2),
           2. ("OpenRatio", "wooden_cabinet_1_middle_region", 0.55),
           3. ("OpenRatio", "wooden_cabinet_1_bottom_region", 0.8),
           This create a staircase as the initial state.
![image](https://github.com/user-attachments/assets/8ec886f1-3d5f-4a0a-8eda-d0f7201c5b7e)

- Files modified: env/bddl_base_domain.py and env/regions/object_property_sampler.py